### PR TITLE
Bump speech-dispatcher dep to 0.13.0

### DIFF
--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -12,7 +12,7 @@ description = "nvda2speechd server"
 
 serde={version="1.0.137", features=["derive"]}
 rmp-serde="1.1.0"
-speech-dispatcher="0.11.0"
+speech-dispatcher="0.13.0"
 tungstenite="0.17.2"
 url="2.2.2"
 


### PR DESCRIPTION
To avoid typing issues with libspeechd 0.11.0, see
https://gitlab.com/ndarilek/speech-dispatcher-rs/-/issues/3